### PR TITLE
Add source language setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LeoTranslate
 
-This is an add-on for the Firefox and Firefox for Android browsers that helps you translate words from English to Russian and let you add these words to the your dictionary.
+This is an add-on for the Firefox and Firefox for Android browsers that helps you translate words from your chosen language into Russian and lets you add these words to your dictionary. You can choose the source language (for example, English or Portuguese) in the settings.
  
 ## Installation
 [Get the Firefox Add-on from AMO gallery](https://addons.mozilla.org/en-US/firefox/addon/leo-translate/)

--- a/src/storage/options.js
+++ b/src/storage/options.js
@@ -23,6 +23,9 @@ export const defaultValues = Object.freeze({
   // Play sound automatically for translated word
   audioAutoPlay:    false,
 
+  // Original language of the text to translate
+  sourceLang: 'en',
+
   // Network settings
   privateMode:      true
 });

--- a/src/vue/TheOptionsPage.vue
+++ b/src/vue/TheOptionsPage.vue
@@ -112,6 +112,16 @@
         </select>
       </label>
 
+      <h3>Translation</h3>
+      <label>
+        Source language<br>
+        <select class="browser-style" v-model="options.sourceLang">
+          <option value="en">English</option>
+          <option value="pt">Portuguese</option>
+          <option value="ru">Russian</option>
+        </select>
+      </label>
+
       <h3>Audio</h3>
       <div class="browser-style">
         <input
@@ -157,7 +167,8 @@
           theme:                null,
           audioAutoPlay:        null,
           contextAutoTranslate: null,
-          privateMode:          null
+          privateMode:          null,
+          sourceLang:          null
         },
       };
     },

--- a/src/vue/TranslateContext.vue
+++ b/src/vue/TranslateContext.vue
@@ -30,6 +30,7 @@
       return {
         showTranslatedContext: false,
         translatedContext: '',
+        sourceLang: 'en'
       };
     },
 
@@ -39,6 +40,7 @@
         this.showTranslatedContext = false;
 
         options.getOption('contextAutoTranslate').then(val => val && this.toggleTranslatedContext());
+        options.getOption('sourceLang').then(lang => this.sourceLang = lang);
       }
     },
 
@@ -47,6 +49,8 @@
           vm => [vm.showTranslatedContext, vm.translatedContext].join(),
           val => this.$emit('resize')
       );
+
+      options.getOption('sourceLang').then(lang => this.sourceLang = lang);
     },
 
     methods: {
@@ -54,7 +58,7 @@
         if (! this.showTranslatedContext && this.translatedContext === '') {
           this.translatedContext = 'Loading...';
 
-          api.translateSentence(this.context, 'en', 'ru')
+          api.translateSentence(this.context, this.sourceLang, 'ru')
               .then(data => this.translatedContext = data.translation);
         }
 


### PR DESCRIPTION
## Summary
- introduce `sourceLang` option with default English
- expose source language selector in the settings page
- use selected language when translating context
- update documentation to mention configurable source language

## Testing
- `npm run web-ext:lint` *(fails: `web-ext: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d39612c8c8321b71b98dd8d9111a0